### PR TITLE
Init: Prepare documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+Describe the problem, feature request, or question. Include context, goals, and why it matters.
+
+## Steps to Reproduce / Proposal
+1. 
+2. 
+3. 
+
+## Expected vs Actual Behaviour
+- **Expected:**
+- **Actual:**
+
+## Environment
+- aavion Studio version / commit:
+- PHP version:
+- Hosting setup (local, shared, container):
+- Browser (if UI related):
+
+## Additional Details
+- Logs, stack traces, or screenshots
+- Related docs/drafts or Worklog entries
+- Suggested solutions or workarounds

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+- [ ] Describe the change and why it matters
+- [ ] List affected modules/features
+
+## Testing
+- [ ] `composer install`
+- [ ] `php bin/phpunit`
+- [ ] `php bin/console tailwind:build`
+- [ ] `php bin/console asset-map:compile`
+- [ ] Other (describe):
+
+## Documentation
+- [ ] Updated relevant guides (README, user/dev manuals, feature drafts)
+- [ ] Updated class map (`docs/dev/classmap.md`)
+- [ ] Logged updates in `docs/codex/WORKLOG.md`
+- [ ] Added screenshots/UI notes if applicable
+
+## Additional Notes
+- [ ] Security/privacy considerations
+- [ ] Follow-up tasks captured in WORKLOG
+- [ ] Linked issues / discussions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 - After each feature/refactor, cross-check code vs. docs; update docs on the spot or record the discrepancy with owner and next steps.
 - When closing a session, read relevant Markdown files end-to-end to catch drift, document outcomes in the worklog, and note pending actions.
 - Prefer non-throwing flows in production code: handle errors, log context-rich messages, and surface recoverable issues gracefully.
+- Follow the documentation style guide (`docs/STYLEGUIDE.md`). Use templates from `docs/templates/` when creating new guides. Place screenshots under `docs/assets/` and update `docs/dev/classmap.md` with new callables.
 
 ## Compatibility & Refactoring Policy
 - Until the first public major release (1.0.0), backwards compatibility is not required. Favour clean refactors over legacy shims and remove obsolete code; update callers and documentation immediately when behaviour changes.
@@ -58,3 +59,14 @@
 - Environment recap: `docs/codex/ENVIRONMENT.md`
 - README entry point: `README.md`
 - Helper scripts & snippets: store under `.codex/`
+- Style guide: `docs/STYLEGUIDE.md`
+- Templates: `docs/templates/`
+
+## Review Guidelines
+- Ensure `docs/codex/WORKLOG.md` session notes and TODOs reflect the change set.
+- Check documentation updates adhere to `docs/STYLEGUIDE.md` (headings, tone, status tags) and leverage templates when applicable.
+- Verify class map entries (`docs/dev/classmap.md`) for new/modified callables; include test references.
+- Confirm PR checklist items are addressed (testing, documentation, screenshots, security notes).
+- Flag any drift between code and feature drafts (`docs/codex/notes/*.md`) and update or log follow-ups.
+- Review tests (unit/integration/UI) for completeness and determinism; ensure coverage for new logic.
+- Run or schedule Markdown link checks; report broken references and update docs during review when possible.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,37 @@
 # aavion Studio
-> :warning: **Caution:**  
-> This project is under active development and not yet ready for production use.  
-> Clone, test, and experiment at your own risk.  
-> Documentation will be added soon.  
 
-**Project-Owner:** Dominik Letica (dominik@aavion.media)  
-**Description:** A content-management-system (CMS) written in PHP using Symfony that is focused on a versioned (git-alike) data-storage with variable fieldsets and llm-friendly exports for different kind of projects.  
-**Status:** WIP – Initializing codebase  
-**Contributions:** Not yet permitted. Feel free to file an issue first before creating a pull-request.  
-**License:** Creative Commons BY-SA 4.0
+> **Status:** Active development (prototype) – :warning: not production-ready  
+> **TL;DR:** Modular Symfony CMS with schema-driven content, Git-like versioning, deterministic snapshots, and LLM-friendly exports.
+
+## Overview
+- **Owner:** Dominik Letica · dominik@aavion.media  
+- **Tech Stack:** PHP 8.2+, Symfony 7.3, SQLite (dual files), Twig, Tailwind, Stimulus, Importmap  
+- **Key Concepts:** Draft → Commit workflow, shortcode resolver pipeline, snapshot-based delivery, optional module system (exporter, navigation, theming, maintenance, etc.)
+- **Roadmap:** See [`docs/codex/WORKLOG.md`](docs/codex/WORKLOG.md) for live TODOs and session logs.
+
+## Documentation
+- **Developer Manual:** [`docs/dev/MANUAL.md`](docs/dev/MANUAL.md)  
+  Architecture, setup scripts, class map, and subsystem guides.
+- **User Manual:** [`docs/user/MANUAL.md`](docs/user/MANUAL.md)  
+  Installation, content authoring, publishing, and administration.
+- **Concept Outline:** [`docs/codex/notes/OUTLINE.md`](docs/codex/notes/OUTLINE.md)  
+  High-level vision, non-functional goals, distribution strategy, and roadmap.
+- **Feature Drafts:** Browse `docs/codex/notes/` for detailed plans (core platform, API, modules, etc.).
+
+## Quick Start
+```bash
+git clone https://github.com/dominikletica/aavionstudio.git
+cd aavionstudio
+bin/init_repository
+symfony serve # or php -S localhost:8000 -t public
+```
+
+The init script installs Composer dependencies, refreshes importmap assets, builds Tailwind CSS, prepares SQLite databases, ensures Messenger transports, and warms up caches.
+
+## Contribution Guidelines
+- External contributions are not yet open. Please use Issues to share feedback or questions.
+- Coding standards: PSR-12, Tailwind utility-first CSS, Stimulus controllers for interactivity.
+- Documentation must remain English. Update relevant manuals whenever behaviour changes.
+
+## Licensing
+Creative Commons BY-SA 4.0 – refer to [`LICENSE`](LICENSE) for details.

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,0 +1,62 @@
+# Documentation Style Guide
+
+> **Purpose:** Provide consistent writing and formatting standards for all documentation (developer, user, codex notes).
+
+## Language & Tone
+- Write in English, concise but descriptive.
+- Use second-person for user guides (“You can…”), neutral tone for developer docs.
+- Avoid colloquialisms; prefer clear, actionable language.
+
+## Structure
+- Each document starts with an H1 title (`# Title`), optionally followed by status metadata (`Status: Draft`).
+- Use sentence case for headings (except product names): `## Getting started`, `### Error handling`.
+- Include a short intro paragraph before diving into detail.
+- Sections should follow a logical order: background → prerequisites → steps → references.
+
+## Formatting
+- Use markdown lists for steps (`1.`) and unordered bullets (`-`).
+- Highlight commands with fenced code blocks (add language hint):
+  ```bash
+  php bin/console tailwind:build
+  ```
+- Inline code uses backticks (`\``).
+- Tables should have headers and alignment pipes.
+- Block quotes (`>`) for callouts or notes; prefix important warnings with **Note**, **Warning**, or **Tip**.
+
+## Naming & Files
+- Developer docs: snake-case file names (`schema-validation.md`); user docs: hyphenated names (`content-authoring.md`).
+- Feature drafts under `docs/codex/notes/` use prefixes (`feat-`, `module-`).
+- Assets (screenshots) go under `docs/assets/` with descriptive names (`admin-dashboard_v1.png`).
+
+## Status Tags
+- Optionally include metadata near the top:
+  ```
+  Status: Draft
+  Updated: 2025-10-29
+  Owner: Team/Core
+  ```
+- Update the `Updated` field when substantial changes occur.
+
+## Cross-Referencing
+- Link to other docs via relative paths (`[Developer Manual](../dev/MANUAL.md)`).
+- When referencing sections, use explicit anchors (`[See draft workflow](content/draft-workflow.md#commit)`).
+- Update `docs/codex/WORKLOG.md` when documentation changes require follow-up.
+
+## Screenshots & Media
+- Store images under `docs/assets/`; include captions or context in the surrounding text.
+- When referencing UI elements, describe the path (e.g., “Go to **Admin → Navigation Builder**”).
+- Ensure screenshots show English UI unless documenting localisation.
+
+## Templates
+- Use templates in `docs/templates/` when creating new guides:
+  - `docs/templates/user-guide-template.md`
+  - `docs/templates/dev-guide-template.md`
+- Document-specific instructions (e.g., module docs) should inherit structure from these templates.
+
+## Review Checklist
+- Confirm table of contents (if present) matches headings.
+- Verify links and image references.
+- Ensure code samples are tested or clearly marked pseudocode.
+- Keep docs aligned with current behaviour; log drift if immediate update is not possible.
+
+Following this guide keeps the documentation clear, predictable, and easy to maintain—especially when multiple agents contribute in parallel.

--- a/docs/codex/WORKLOG.md
+++ b/docs/codex/WORKLOG.md
@@ -4,19 +4,150 @@
 > Purpose: Track implementation decisions, open questions, and follow-up tasks during development.
 
 ## TODO
-### Core Platform
-- [ ] Example
+### Core Platform (P0 | XL)
+- [ ] Finalise hosting strategy (rewrite-first vs root fallback) and bake checks into installer
+- [ ] Prepare initial Doctrine migrations for project/entity/version/draft/schema tables
+- [ ] Implement module manifest loader (services, routes, UI navigation) with enable/disable flags
+- [ ] Wire dual SQLite attach listener with health checks and busy timeout configuration
+- [ ] Create unit/integration test harness for installer, module loader, and database bootstrap
 
-### Example Feature
-- [ ] Example
+### Feat: User Management & Access Control (P0 | L)
+- [ ] Create user entity, login flow, and password reset process
+- [ ] Seed role hierarchy + capability registry sourced from module manifests
+- [ ] Build admin UI for user/role/API key management with audit logging
+- [ ] Cover authentication, role assignment, and API-key flows with functional/security tests
+
+### Feat: Admin Studio UI (P0 | L)
+- [ ] Scaffold layout (sidebar, header, notifications) with Tailwind components
+- [ ] Wire navigation builder consuming module manifests + capability checks
+- [ ] Implement search palette and contextual help drawer
+- [ ] Add Cypress/Stimulus integration tests (or Symfony Panther) for core navigation UX
+
+### Feat: Schema & Template System (P0 | L)
+- [ ] Implement schema/template persistence with versioning
+- [ ] Integrate JSON schema validation into draft workflow
+- [ ] Build admin schema builder + template preview tools
+- [ ] Write unit tests for schema validation + template resolution helpers
+
+### Feat: Draft & Commit Workflow (P0 | L)
+- [ ] Build DraftManager service with autosave + optimistic locking
+- [ ] Implement commit transaction promoting drafts to active versions with event dispatch
+- [ ] Integrate editor UI (CodeMirror + schema validation) with status indicators
+- [ ] Add feature tests covering draft autosave, conflict handling, and commit lifecycle
+
+### Feat: Snapshot & API Delivery (P0 | L)
+- [ ] Implement SnapshotManager with atomic writer and metadata tracking
+- [ ] Expose read-only API endpoints with caching headers and rate limiting
+- [ ] Add CLI commands for snapshot rebuild and pruning
+- [ ] Provide integration tests validating snapshot generation and API responses
+
+### Feat: Frontend Delivery & Rendering (P0 | L)
+- [ ] Implement catch-all frontend controller backed by snapshots and schema templates
+- [ ] Build base Twig layouts with error page handling and navigation integration
+- [ ] Add preview mode for drafts with access controls
+- [ ] Ensure error-page entities in `default` project fall back to seeded Twig templates (render tests)
+- [ ] Write functional tests for routing, locale handling, and preview safeguards
+
+### Feat: Resolver Pipeline (P1 | L)
+- [ ] Implement shortcode tokenizer and schema field annotations
+- [ ] Build reference and query resolver services with cycle detection
+- [ ] Surface resolver warnings/errors in commit UI and logs
+- [ ] Add unit tests covering resolver operators, cycle detection, and error codes
+
+### Feat: Caching & Performance Strategy (P1 | M)
+- [ ] Configure cache namespaces/adapters and default TTLs
+- [ ] Hook cache invalidation into snapshot and draft events
+- [ ] Expose cache stats/controls via maintenance module
+- [ ] Benchmark cache hit/miss scenarios; add tests for invalidation hooks
+
+### Feat: Write API & Integration Surface (P1 | M)
+- [ ] Define OpenAPI spec for write endpoints and response contracts
+- [ ] Implement API key scope checks and HMAC signing support
+- [ ] Build webhook dispatcher with retry queue
+- [ ] Create API integration tests (success + failure paths, rate limits, signatures)
+
+### Feat: Media Storage & Delivery (P0 | L)
+- [ ] Implement media storage abstraction, metadata persistence, and upload workflows
+- [ ] Build protected delivery controller with signed URLs and ACL checks
+- [ ] Integrate media fields into schema/editor and exporter pipelines
+- [ ] Add cleanup command for orphaned assets and retention policies
+- [ ] Cover upload, metadata, and download flows with integration tests
+
+### Module: Relation Manager (P1 | M)
+- [ ] Implement hierarchy service with materialized path operations
+- [ ] Build drag-and-drop tree UI for entity arrangement
+- [ ] Emit hierarchy change events for downstream modules
+- [ ] Write tests for hierarchy integrity, move operations, and UI endpoints
+
+### Module: Navigation Builder (P1 | M)
+- [ ] Design menu/menu-item persistence and draft workflow
+- [ ] Create admin tree editor with visibility rules
+- [ ] Provide frontend renderer + sitemap generator
+- [ ] Test menu rendering, sitemap output, and visibility rules
+
+### Module: Frontend Theming & Site Delivery (P1 | L)
+- [ ] Implement theme manifest loader and activation flow
+- [ ] Build theme management UI with preview functionality
+- [ ] Integrate Tailwind build pipeline for multiple themes
+- [ ] Add tests ensuring theme overrides render correctly and fallbacks apply
+
+### Module: Exporter (P1 | M)
+- [ ] Implement export presets + JSON/JSONL writers
+- [ ] Build admin UI for presets and run history
+- [ ] Add optional TOON converter behind feature flag
+- [ ] Provide tests verifying export content, presets, and TOON feature flag behaviour
+
+### Module: Admin Maintenance Console (P1 | M)
+- [ ] Create dashboard cards for cache, snapshots, queue, migrations
+- [ ] Wrap CLI operations in services for UI-triggered actions
+- [ ] Add health check aggregations (permissions, disk usage, extensions)
+- [ ] Add functional tests for maintenance actions and permission boundaries
+
+### Module: Backup & Restore (P1 | L)
+- [ ] Implement backup command + archive manifest with checksums
+- [ ] Build admin UI for scheduling, download, restore
+- [ ] Add retention policy and optional remote storage hooks
+- [ ] Test backup archives, restore flows, and scheduling/retention logic
+
+### Module: Diff View (P2 | M)
+- [ ] Develop diff engine for JSON/Markdown comparison
+- [ ] Integrate diff viewer into admin UI and commit modal
+- [ ] Cache diff results for common comparisons
+- [ ] Cover diff edge cases (large payloads, markdown comparison) with tests
 
 ## Roadmap To Next Release
-- [ ] **Step 1:** Example
+- [ ] **Step 1:** Discuss open questions & confirm hosting/security decisions
+- [ ] **Step 2:** Implement Core Platform & architecture foundation
+- [ ] **Step 3:** Implement User Management & Access Control
+- [ ] **Step 4:** Build Admin Studio UI shell & navigation
+- [ ] **Step 5:** Deliver Schema/Template system & Draft/Commit workflow
+- [ ] **Step 6:** Implement Snapshot delivery, Frontend rendering, and Resolver pipeline
+- [ ] **Step 7:** Add Media storage, Caching strategy, and Write API integration
+- [ ] **Step 8:** Ship priority modules (Relation, Navigation, Theming, Exporter, Maintenance, Backup)
+- [ ] **Step 9:** Polish stretch module (Diff View) & regression test suite
 
 ## Planned Implementations, Outlined Ideas
 > Concept drafts live in `docs/codex/notes/*.md`
 
 - [Project Outline](./notes/OUTLINE.md)
+- [Feat: Core Platform (P0 | XL)](./notes/feat-core-platform.md)
+- [Feat: Draft & Commit Workflow (P0 | L)](./notes/feat-draft-commit.md)
+- [Feat: Resolver Pipeline (P1 | L)](./notes/feat-resolver-pipeline.md)
+- [Feat: Snapshot & API Delivery (P0 | L)](./notes/feat-snapshot-api.md)
+- [Feat: Frontend Delivery & Rendering (P0 | L)](./notes/feat-frontend-delivery.md)
+- [Feat: User Management & Access Control (P0 | L)](./notes/feat-user-access.md)
+- [Feat: Admin Studio UI (P0 | L)](./notes/feat-admin-studio.md)
+- [Feat: Schema & Template System (P0 | L)](./notes/feat-schema-templates.md)
+- [Feat: Media Storage & Delivery (P0 | L)](./notes/feat-media-storage.md)
+- [Feat: Write API & Integration Surface (P1 | M)](./notes/feat-api-write.md)
+- [Feat: Caching & Performance Strategy (P1 | M)](./notes/feat-caching-strategy.md)
+- [Module: Exporter (P1 | M)](./notes/module-exporter.md)
+- [Module: Admin Maintenance Console (P1 | M)](./notes/module-admin-maintenance.md)
+- [Module: Relation Manager (P1 | M)](./notes/module-relation-manager.md)
+- [Module: Navigation Builder (P1 | M)](./notes/module-navigation.md)
+- [Module: Frontend Theming & Site Delivery (P1 | L)](./notes/module-frontend-theming.md)
+- [Module: Backup & Restore (P1 | L)](./notes/module-backup-restore.md)
+- [Module: Diff View (P2 | M)](./notes/module-diff-view.md)
 
 ## Session Logs
 ### 2025-10-29
@@ -27,3 +158,10 @@
 - Updated `.env` defaults for SQLite, configured messenger/lock cache, confirmed runtime via `php bin/console about`
 - Created contributor guide (`AGENTS.md`) and aligned docs under `docs/codex/**`
 - Translated and updated project outline to English with deployment strategy revisions
+
+### 2025-10-29 (Session 2)
+- Kicked off feature-outline drafting for modular architecture and implementation planning
+- Added detailed drafts for core platform, workflow, resolver, snapshot/API, and initial modules
+- Established documentation style guide, templates, manuals, and tooling for parallel doc updates
+- Expanded draft library covering user management, admin studio, schema/templates, write API, caching, theming, navigation, backup, and diff tooling
+- Reorganised TODOs by feature/module with granular tasks for implementation planning

--- a/docs/codex/notes/feat-admin-studio.md
+++ b/docs/codex/notes/feat-admin-studio.md
@@ -1,0 +1,53 @@
+# Feat: Admin Studio UI (P0 | Scope: L)
+
+**Status:** Draft – subject to iteration with UX feedback.  
+**Purpose:** Deliver a cohesive admin experience with modular navigation, themable layout, and extensibility hooks for feature modules.
+
+## Core Experiences
+- Responsive layout with sidebar navigation, top bar status indicators, and workspace canvas.
+- Module-driven navigation: manifests contribute menu items, icons, and feature flags.
+- Notification centre (toasts + persistent panel) for background tasks and system alerts.
+- Search command palette (`⌘K`) to quickly jump to entities, modules, or commands.
+- Contextual help drawer linking to docs, tooltips, inline guides.
+
+## Technical Stack
+- Twig templates + Tailwind components with Stimulus controllers for interactions.
+- Turbo-powered navigation (partial reloads) to keep stateful widgets responsive.
+- Global state store (Stimulus values or lightweight Alpine integration) for toasts, modals.
+- Accessibility-first design (ARIA labels, keyboard shortcuts, focus management).
+
+## Module Integration
+- Navigation manifest structure:
+  ```yaml
+  navigation:
+    - label: "Content"
+      icon: "content"
+      route: "aavion_admin_content"
+      capability: "content.view"
+      children:
+        - label: "Drafts"
+          route: "aavion_admin_drafts"
+  ```
+- Modules can inject dashboards cards, actions, or tabs via named Twig blocks.
+- Provide UI kit components (buttons, cards, tables) as reusable Twig macros/Stimulus wrappers.
+
+## Theming
+- Base theme defined with CSS variables; allow per-instance overrides (dark mode, brand colours).
+- Module-specific styles scoped via utility classes to avoid conflicts.
+- Optional theme pack loader for rapid skinning (later module).
+
+## Internationalisation
+- All strings in `admin` translation domain; support per-user locale selection.
+- Date/time formatting using Intl; numeric formatting respecting locale.
+
+## Implementation Roadmap
+1. Scaffold base layout (sidebar, header, breadcrumbs, notifications).
+2. Wire navigation builder to module manifest registry with capability checks.
+3. Implement shared UI components (tables, detail panels, modals).
+4. Add search palette + quick actions.
+5. Bake in help drawer and context docs hooks.
+
+## Open Questions
+- Should modules be able to register client-side bundles (React/Vue) or keep to Stimulus-only?
+- How do we package custom themes for distribution (zip, composer metapackage)?
+- Do we need multi-tenant branding (per project) within the same admin instance?

--- a/docs/codex/notes/feat-api-write.md
+++ b/docs/codex/notes/feat-api-write.md
@@ -1,0 +1,43 @@
+# Feat: Write API & Integration Surface (P1 | Scope: M)
+
+**Status:** Draft – final endpoints subject to later review.  
+**Intent:** Extend the read-only snapshot API with authenticated write capabilities and integration touchpoints (webhooks, SDKs).
+
+## Use Cases
+- External tools creating/updating entities (e.g., headless editors, migration scripts).
+- Automation triggers committing changes instantly or staging drafts.
+- Integration with partner platforms via webhooks or polling.
+
+## API Design
+- REST endpoints under `/api/v1/admin/...` requiring API key with `write` scope.
+- Core routes:
+  - `POST /projects/{project}/entities` → create draft (payload + schema id)
+  - `PUT /projects/{project}/entities/{slug}` → update existing (draft or instant commit)
+  - `POST /projects/{project}/entities/{slug}/commit` → promote draft with message
+  - `POST /projects/{project}/snapshots/regenerate` → queue snapshot rebuild
+- Support `dry_run=true` to validate payload without persisting.
+
+## Security
+- HMAC request signing (optional) to prevent tampering.
+- Rate limits separate from read API; configurable burst/steady tokens.
+- Fine-grained scopes (`content.write`, `snapshot.manage`, `export.run`).
+
+## Webhooks
+- Deliver events (`entity.committed`, `snapshot.published`, `export.completed`) to configured URLs.
+- Retry with exponential backoff; log failures with admin notifications.
+
+## SDK / CLI
+- Provide PHP/JS SDK interfaces for common operations (optional step).
+- CLI commands for import/export use the same API service for consistency.
+
+## Implementation Steps
+1. Define API request/response schemas and integrate with Symfony Serializer.
+2. Implement authentication guard for API keys + scope checks.
+3. Build controllers delegating to existing services (DraftManager, SnapshotManager).
+4. Add webhook dispatcher + delivery queue (Messenger).
+5. Publish API reference (OpenAPI spec) and developer quickstart docs.
+
+## Open Questions
+- Do we expose granular permissions per schema or entity type?
+- Should webhooks support signing secrets per endpoint?
+- Is GraphQL support desirable or can be deferred indefinitely?

--- a/docs/codex/notes/feat-caching-strategy.md
+++ b/docs/codex/notes/feat-caching-strategy.md
@@ -1,0 +1,35 @@
+# Feat: Caching & Performance Strategy (P1 | Scope: M)
+
+**Status:** Draft – final tuning pending real-world benchmarks.  
+**Goal:** Define cache layers to keep the CMS responsive on shared hosting while supporting scale-out scenarios.
+
+## Cache Layers
+- **HTTP Cache:** Symfony HTTP cache (reverse proxy headers) with configurable TTL per route; optional integration with CDN.
+- **Application Cache:** Use `cache.app` (filesystem by default) for expensive computations (resolver results, navigation trees).
+- **Doctrine Result Cache:** Enable for snapshot metadata queries; fallback to SQLite if storage limited.
+- **Frontend Asset Cache:** AssetMapper hashed filenames + long-lived cache headers; Tailwind compiled CSS referenced via manifest.
+
+## Invalidations
+- Snapshot publish clears relevant cache namespaces (snapshot readers, navigation).
+- Draft commits flush resolver cache entries for affected entities.
+- Admin maintenance module triggers manual cache clear/warmup.
+
+## Configuration
+- Environment-specific cache adapters (filesystem dev, Redis prod optional).
+- Busy shared hosting: provide toggle to limit cache size & eviction policy.
+- Support `.env` overrides for cache TTL per component.
+
+## Tooling
+- Commands: `app:cache:prune`, `app:cache:stats`.
+- Monitoring hooks for cache hit/miss metrics (hook into Monolog or dedicated table).
+
+## Implementation Steps
+1. Define cache namespaces and adapters in `config/packages/cache.yaml`.
+2. Integrate cache invalidation in snapshot/draft services.
+3. Add HTTP caching headers to API + frontend controllers.
+4. Instrument logging to observe cache behaviour.
+
+## Open Questions
+- Do we require Redis support out-of-the-box or provide as optional module?
+- How aggressive should default TTLs be for shared hosting vs dedicated environments?
+- Should we expose cache configuration to admins via UI or keep .env-driven?

--- a/docs/codex/notes/feat-core-platform.md
+++ b/docs/codex/notes/feat-core-platform.md
@@ -1,0 +1,62 @@
+# Feat: Core Platform (P0 | Scope: XL)
+
+**Status:** Draft – subject to refinement as implementation progresses.  
+**Goal:** Establish the foundational Symfony architecture, module system, and runtime services that every other feature depends on.
+
+## Overview
+- Symfony 7.3 skeleton enhanced with shared-hosting compat (public webroot + root fallback loader).
+- Dual SQLite data stores (`system.brain`, `user.brain`) with Doctrine ORM and custom attach listener.
+- Modular service registration: each feature can expose backend services, console commands, routes, and Vue/Stimulus controllers through a structured manifest.
+- Unified configuration layer: environment variables defaulted in `.env`, overrides via installer-generated `.env.local.php`.
+
+## Architecture Components
+1. **Kernel & Bundles**
+   - Base bundles: FrameworkBundle, Doctrine (ORM, Migrations), Security, Messenger, RateLimiter, Translation, Serializer, Monolog, Notifier.
+   - Custom service tags to auto-register module providers (e.g., `aavion.module`).
+2. **Module Discovery**
+   - Directory `modules/<slug>/module.php` returns a manifest:
+     ```php
+     return new ModuleManifest(
+         name: 'Version Manager',
+         priority: 100,
+         services: 'modules/version-manager/config/services.php',
+         routes: 'modules/version-manager/config/routes.yaml',
+         adminNavigation: [
+             new AdminLink('Version Manager', route: 'aavion_admin_version_manager'),
+         ],
+     );
+     ```
+   - Module loader compiles manifests at cache warmup; supports enable/disable flags stored in `system.brain`.
+3. **Installer Pipeline**
+   - Health checks: PHP version, required extensions, writable directories, SQLite availability.
+   - Steps: configure base settings → create admin user → generate secrets → run migrations.
+   - Persist installation state to prevent reruns.
+4. **Fallback Bootstrap**
+   - Root `index.php` delegates to `public/index.php`, optionally routing through `?route=` param.
+   - Security warning banner in installer when rewrite/docroot not enforced.
+
+## Data Layer
+- Doctrine naming consistent with ULID primary keys.
+- Table naming convention: `app_<domain>` (`app_project`, `app_entity`, `app_entity_version`, `app_draft`, `app_schema`, `app_template`, `app_relation`, `app_api_key`, `app_user`, `app_log`).
+- Doctrine type overrides: register `ulid`, `uuid`, JSON column helper.
+- Migrations must include triggers or checks for materialized path integrity.
+
+## Module Integration
+- Admin UI nav composed from module manifests (sorted by priority).
+- Routes isolated per module under `/admin/<module-slug>`; fallback to catch-all for modules without UI.
+- AssetMapper pipeline loads Stimulus controllers from `modules/*/assets/controllers`.
+
+## Implementation Phases
+1. Build module manifest contracts + loader (hard dependencies: DI container & cache warmup).
+2. Implement installer controller + steps, persisting state in `system.brain`.
+3. Scaffold Doctrine migrations for core tables, including attach listener wiring & connection tests.
+4. Provide root bootstrap file with diagnostics + manual security checklist.
+
+## Risks & Mitigations
+- **Shared hosting constraints:** Document manual configuration, surface warnings in installer.
+- **Module misconfiguration:** Validate manifests during cache warmup; fail fast with actionable errors.
+- **SQLite locking:** Use `PRAGMA busy_timeout`; consider DB-level locks via Symfony Lock when publishing.
+
+## Dependencies & Interfaces
+- Depends on: Doctrine ORM, Messenger (later phases), Symfony Cache/Lock, Installer UI templates.
+- Provides: Module loader service, configuration registry, event dispatcher hooks for other features.

--- a/docs/codex/notes/feat-draft-commit.md
+++ b/docs/codex/notes/feat-draft-commit.md
@@ -1,0 +1,48 @@
+# Feat: Draft & Commit Workflow (P0 | Scope: L)
+
+**Status:** Draft blueprint – to be refined during implementation.  
+**Goal:** Provide a deterministic content authoring pipeline: drafts, autosave, commit with optional diff, and version activation.
+
+## Functional Breakdown
+- Draft creation: duplicate latest active `EntityVersion` into `Draft`.
+- Autosave: periodic PATCH to store partial changes; maintain `updated_at` + `updated_by`.
+- Commit: promote draft to new `EntityVersion`, mark previous version inactive, optionally capture commit message and change summary.
+- Locking: prevent concurrent edits via optimistic locking (version column) + advisory lock using Symfony Lock.
+- UI: Editor module (CodeMirror + JSON schema form) with state indicators (draft saved, needs commit).
+
+## API & Services
+- `DraftManager` service:
+  - `createDraft(Entity $entity, User $user)`
+  - `updateDraft(Draft $draft, array $payload)`
+  - `commitDraft(Draft $draft, CommitOptions $options)`
+- Validation handled via JSON schema registry before commit.
+- Event dispatch (`DraftCommittedEvent`) for downstream tasks (resolver, snapshot).
+
+## Data Requirements
+- Tables: `app_draft`, `app_entity_version`, `app_entity`.
+- Fields:
+  - Draft: ULID `id`, FK `entity_id`, `payload_json`, `updated_by`, `updated_at`, `autosave` (bool).
+  - Version: ULID `version_id`, FK `entity_id`, `payload_json`, `author_id`, `committed_at`, `commit_message`, `active_flag`.
+- Indices: `draft.entity_id` unique (one draft per entity per user), `version.entity_id` for quick history.
+
+## UI Flow
+1. Load existing draft (if any) or create new.
+2. Editor auto-saves every N seconds or on blur; show toast/banner for status.
+3. Commit modal: input message, optional diff preview (hook to diff module later).
+4. After commit, refresh active version view + timeline.
+
+## Dependencies
+- Requires core platform (module loader, schema validator).
+- Triggers: resolver pipeline, snapshot pipeline.
+- Exposes hooks for modules (e.g., Diff View to display comparisons in commit modal).
+
+## Implementation Sequence
+1. Draft entity + repository, JSON validation, autosave endpoints.
+2. Commit service with transaction; ensure active version switch is atomic.
+3. UI integration within Admin Studio layout.
+4. Events/tests to confirm concurrency rules.
+
+## Known Considerations
+- Concurrency: adopt row-level locking or compare `updated_at` tokens on commit to prevent stale overwrite.
+- Audit trail: store minimal diffs for future diff module (optional at MVP).
+- Large payloads: consider compression or streaming if payloads exceed threshold (deferred).

--- a/docs/codex/notes/feat-frontend-delivery.md
+++ b/docs/codex/notes/feat-frontend-delivery.md
@@ -1,0 +1,29 @@
+# Feat: Frontend Delivery & Rendering (P0 | Scope: L)
+
+**Status:** Draft – will be refined once schema and snapshot layers stabilise.  
+**Goal:** Render published content to the public site using Twig templates, navigation menus, and snapshots as the data source.
+
+## Deliverables
+- Catch-all controller under `src/Controller/Frontend` that resolves project + path, pulls data from `SnapshotReader`, and renders Twig templates bound to schema definitions.
+- Error page handling (403/404/5xx) driven by entity assignments; fallback to static templates when mapping missing.
+- Layout composition using theme module (if active) or default Twig layouts.
+- Dynamic meta tags (title, description, OG tags) derived from snapshot metadata and schema fields.
+- Multi-locale support: map `/en/...` vs `/de/...` based on project configuration.
+
+## Integration Points
+- Navigation Builder provides menus consumed by base layout.
+- Schema/Template system supplies Twig templates referenced per entity type.
+- Snapshot manager ensures fast lookup; caching layer adds HTTP caching headers.
+- Feature flags allow preview mode (render draft via query param) for admins.
+
+## Implementation Steps
+1. Implement routing strategy (project resolver + slug path) with cached lookup of route map.
+2. Build `SnapshotReader` helpers for entity, listing, and related-content fetch.
+3. Create base Twig layout with slots for navigation, breadcrumbs, content, footer.
+4. Wire schema-based template resolution (e.g., `schema_render(entity)`).
+5. Handle error pages and preview mode toggles.
+
+## Open Questions
+- Do we need per-project routing customisation (e.g., custom controllers for certain types)?
+- How should we guard preview mode so only authenticated admins can access draft views?
+- Should we embed structured data (JSON-LD) automatically based on schema metadata?

--- a/docs/codex/notes/feat-media-storage.md
+++ b/docs/codex/notes/feat-media-storage.md
@@ -1,0 +1,40 @@
+# Feat: Media Storage & Delivery (P0 | Scope: L)
+
+**Status:** Draft – adjustments expected during implementation.  
+**Purpose:** Provide upload handling, metadata management, secured delivery, and integration with schema fields and exporter workflows.
+
+## Capabilities
+- File ingestion via admin UI (single + bulk) and resolver references.
+- Storage layout `data/uploads/<hash>/<filename>` with checksum, MIME, size, owner, ACL metadata persisted in `system.brain`.
+- Image derivative support (thumbnails) using on-demand generation (optional phase).
+- Protected delivery via controller with signed URL + expiry; public assets served directly.
+- Garbage collection for orphaned files and version-aware retention.
+
+## Services
+- `MediaStorage` abstraction (local adapter first, future cloud adapters).
+- `MediaMetadataRepository` for lookup and lifecycle state.
+- `SignedUrlGenerator` using HMAC + TTL; integrates with Download controller.
+- Validation pipeline (size/mime whitelist, virus scan hook placeholder).
+
+## Admin Experience
+- `/admin/media` browser with filters (project, schema usage, owner).
+- Upload widget integrated into Draft editor fields.
+- Preview modal (image/video) and metadata editor (alt text, captions).
+
+## Schema Integration
+- Schema field type `media` referencing media IDs with constraints (single/multi, type filter).
+- Resolver ensures referenced media exists and is published.
+- Exporter includes media references + signed download URLs when required.
+
+## Implementation Steps
+1. Implement storage abstraction + metadata tables/migrations.
+2. Build upload controller (chunked optional) and admin browser UI.
+3. Add delivery controller (public + protected) with signature validation.
+4. Integrate schema field + editor component.
+5. Add cleanup command for orphaned/unreferenced media.
+6. Optional: add thumbnail pipeline, remote adapter interface.
+
+## Open Questions
+- Do we require per-project storage quotas? If so, where to enforce?
+- Should we integrate a configurable virus scanning hook before persisted?
+- How will CDN integration work for public assets (document expected rewrites)?

--- a/docs/codex/notes/feat-resolver-pipeline.md
+++ b/docs/codex/notes/feat-resolver-pipeline.md
@@ -1,0 +1,51 @@
+# Feat: Resolver Pipeline (P1 | Scope: L)
+
+**Status:** Draft concept – subject to change during development.  
+**Purpose:** Resolve `[ref]` and `[query]` shortcodes deterministically during commit/publish while leaving authoring content intact.
+
+## Responsibilities
+- Parse content blocks (Markdown, rich text, JSON fields) for shortcode tokens.
+- Resolve references against current draft/active data with cycle detection.
+- Produce resolved payloads stored in the published snapshot (original content retains markers).
+- Surface validation errors with machine-readable codes and localisation keys.
+
+## Pipeline Stages
+1. **Tokenisation:** Twig TokenParser or custom lexer scans fields flagged as resolvable.
+2. **Validation:** Ensure referenced entities exist, queries are well-formed, operators supported.
+3. **Execution:** Fetch data via repository abstractions; apply filters (`select`, `where`, `sort`, `limit`).
+4. **Enrichment:** Embed resolved data (inline string, array, object) and attach meta (source entity, timestamp).
+5. **Sanitisation:** Strip resolved data when draft reopens to keep authors editing markers only.
+
+## Services & Components
+- `ResolverEngine` orchestrates steps; invoked during `DraftCommittedEvent` and snapshot rebuild.
+- `ReferenceResolver` handles `[ref …]`: Follows relations, returns canonical slug/title/URL tuple.
+- `QueryResolver` executes filtered lookups; configurable mode (single object vs array).
+- `CycleGuard` tracks visited entity/version pairs to avoid infinite loops.
+- `ResolverLogger` persists warnings to `app_log` with actionable messages.
+
+## Configuration
+- Resolvable fields defined in schema YAML/JSON (`resolvable: true`, `resolver: query|ref`).
+- Feature flags allow disabling resolver per project (for debugging).
+- Custom operators can be registered via module manifests.
+
+## Error Handling
+- Soft failures: replace content with placeholder + inject error metadata for UI to highlight.
+- Hard failures: abort commit/publish with summary (e.g., missing required ref).
+- All messages translated via `validators` domain.
+
+## Integration Points
+- Draft commit service triggers resolver pre-publish; optionally allow "commit with warnings".
+- Snapshot writer receives resolved payload for final JSON.
+- API/exporters rely on snapshot; no runtime resolving required.
+
+## Implementation Order
+1. Token parser + schema flag wiring.
+2. Reference resolver (+ tests around self/reference loops).
+3. Query resolver with filter parser.
+4. Cycle guard + error reporting.
+5. Module extension points (custom resolvers).
+
+## Considerations
+- Performance: cached lookups per commit to minimise DB hits.
+- Security: ensure resolver sanitises user-controlled input (no SQL injection, safe parameter binding).
+- Future: allow resolver previews in editor (AJAX call).

--- a/docs/codex/notes/feat-schema-templates.md
+++ b/docs/codex/notes/feat-schema-templates.md
@@ -1,0 +1,43 @@
+# Feat: Schema & Template System (P0 | Scope: L)
+
+**Status:** Draft – will evolve alongside content modelling needs.  
+**Aim:** Allow administrators to define JSON schemas, attach Twig templates, and drive content rendering/export through structured definitions.
+
+## Components
+- **Schema Registry:** Stores JSON Schema documents per project/global scope; versioned with status (draft/active).
+- **Field Definitions:** Support data types (string, markdown, rich-text, relation, media, computed) with validation rules and UI metadata (labels, help text, component hint).
+- **Template Registry:** Twig templates referencing schema fields; metadata for target channel (web, email, export).
+- **Template Packs:** Bundled schema + templates for reuse/import/export.
+
+## Authoring Flow
+1. Create schema via builder (JSON editor or form-based UI).
+2. Assign schema to entity types; specify allowed children, relation rules.
+3. Link templates to schemas; preview rendering with sample data.
+4. Publishing a schema triggers validation against existing content; warn about breaking changes.
+
+## Rendering Integration
+- Twig runtime extensions provide helpers (`schema_field(entity, 'title')`, `schema_iterate(...)`).
+- Templates resolve through snapshot data to ensure deterministic output.
+- Modules can contribute template filters/functions via manifest.
+
+## Validation
+- Use `justinrainbow/json-schema` for server-side validation.
+- Pre-commit validation ensures payload matches active schema version.
+- Provide migration assistance: detect incompatible changes, enable diff view.
+
+## Import/Export
+- Schema/Template pack format (`.aavpack` JSON + Twig files zipped).
+- Installer seeds default pack (blog/docs).
+- Command-line utilities: `app:schema:export`, `app:schema:import`.
+
+## Implementation Stages
+1. Persistence models (`app_schema`, `app_template`), versioning strategy.
+2. Validation service + integration in draft commit pipeline.
+3. Admin UI for schema builder (initially JSON editor + docs).
+4. Template preview system (render sandbox with sanitized data).
+5. Pack import/export + pack registry view.
+
+## Open Questions
+- Should we support schema inheritance / composition out of the gate?
+- How do we allow third-party modules to ship schema packs (Composer package vs manual upload)?
+- Do we need runtime template sandboxing to guard against heavy Twig logic?

--- a/docs/codex/notes/feat-snapshot-api.md
+++ b/docs/codex/notes/feat-snapshot-api.md
@@ -1,0 +1,47 @@
+# Feat: Snapshot & API Delivery (P0 | Scope: L)
+
+**Status:** Draft – implementation details may evolve.  
+**Objectives:** Persist deterministic JSON snapshots per project and expose them through the Symfony HTTP layer and REST API.
+
+## Snapshot Writer
+- Triggered post-commit or manual rebuild.
+- Writes to `data/snapshots/<project>/<slug>.json` (configurable segmentation by entity type).
+- Uses temp file + atomic rename to avoid partial writes.
+- Stores metadata (hash, generated_at, generator_version) in `system.brain`.
+- Supports per-project delivery mode (public file vs controller streaming).
+
+## Read Layer
+- Frontend controllers load snapshot segments via dedicated `SnapshotReader` service.
+- API routes: `/api/v1/projects/{project}/entities/{slug}` etc. respond with snapshot data, not live DB.
+- ETag/Last-Modified headers derived from metadata for caching.
+- Rate limiting (via Symfony RateLimiter) on API group with per-key quotas.
+
+## Services
+- `SnapshotManager`: orchestrates generation, metadata persistence, event dispatch.
+- `SnapshotStorage`: abstraction to read/write (local filesystem now, S3 plugin later).
+- `SnapshotGuard`: ensures directories exist, handles cleanup of obsolete files.
+- `SnapshotChecksumService`: calculates hash + optional signature for integrity.
+
+## API Contracts
+- JSON:API-like structure for entity payloads (type, id, attributes, relationships).
+- Dedicated route for full project snapshot download (ZIP or JSON).
+- Pagination for listing endpoints (`/api/v1/projects/{project}/entities`).
+- Authentication via API keys; scopes define read access per project.
+
+## Integration Flow
+1. Draft commit triggers resolver → snapshot writer.
+2. Snapshot manager queues heavy writes via Messenger if runtime threshold exceeded.
+3. Frontend & API controllers request data exclusively through `SnapshotReader`.
+4. Exporter module consumes snapshot metadata to build packages.
+
+## Implementation Sequence
+1. Define snapshot storage paths + metadata schema.
+2. Implement synchronous writer + integration tests (temp rename, hash).
+3. Build API controllers + serialization logic (with Symfony Serializer).
+4. Introduce optional async via Messenger transport (delayed).
+5. Add CLI commands: `snapshot:rebuild`, `snapshot:prune`.
+
+## Considerations
+- Shared hosting: ensure `data/snapshots` writable; document fallback when using root loader.
+- Large snapshots: consider chunking or streaming; implement incremental diffs later.
+- Security: guard controller route when `public delivery` disabled; log snapshot rebuilds.

--- a/docs/codex/notes/feat-user-access.md
+++ b/docs/codex/notes/feat-user-access.md
@@ -1,0 +1,41 @@
+# Feat: User Management & Access Control (P0 | Scope: L)
+
+**Status:** Draft – details may be refined during implementation.  
+**Objective:** Provide authentication, role-based authorisation, and fine-grained ACLs across core and modular features.
+
+## Functional Requirements
+- User accounts with password-based login (Symfony Security) and optional 2FA (future phase).
+- Role hierarchy (`ROLE_VIEWER`, `ROLE_EDITOR`, `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`) plus feature-scoped permissions.
+- ACL policies that map module capabilities (e.g., Exporter, Relation Manager) to roles.
+- Session management with remember-me support; enforce secure cookies and CSRF protection for all forms/actions.
+- API keys per user with scopes for read/write operations.
+
+## Architecture Overview
+- Security bundle configured with user provider backed by `app_user` table (ULID id, email, password hash, profile JSON, locale).
+- Permission registry: modules register capabilities (`content.publish`, `export.run`) via manifest; installer seeds roles with defaults.
+- Middleware:
+  - Voters for entity-level access (draft ownership, project membership).
+  - Route attributes for capability checks (`#[IsGranted('export.run')]`).
+- Password reset flow: signed URLs + token storage in `system.brain`.
+
+## Admin UI
+- `/admin/users` module (core) lists accounts, role assignments, API keys.
+- Form-driven editor with validation, optional invitation emails.
+- Audit log integration: record login attempts, role changes, API key creation.
+
+## API & Integrations
+- Bearer API keys for programmatic access; hashed storage with last-used metadata.
+- OAuth2 / SSO left for future module; design interfaces to allow pluggable user providers.
+- Webhooks triggerable per module (e.g., notifier for failed login).
+
+## Implementation Milestones
+1. User entity + Doctrine migration; password hasher config; login/logout controllers.
+2. Role hierarchy + capability registry; integrate with module manifest loader.
+3. Admin UI for accounts, API keys, role assignment.
+4. ACL voters and unit tests covering project/content access scenarios.
+5. Optional enhancements: 2FA, account lockout, session revocation.
+
+## Open Questions
+- Should projects support per-project roles distinct from global roles?
+- Do we require audit trails for every permission change (e.g., append-only log)?
+- Will SSO/OAuth be mandatory for enterprise customers, and how to modularise it?

--- a/docs/codex/notes/module-admin-maintenance.md
+++ b/docs/codex/notes/module-admin-maintenance.md
@@ -1,0 +1,39 @@
+# Module: Admin Maintenance Console (P1 | Scope: M)
+
+**Status:** Draft – details may adjust as other systems solidify.  
+**Mission:** Offer a unified interface for operational tools (cache, snapshot rebuild, export triggers, migration runner).
+
+## Capabilities
+- Dashboard under `/admin/maintenance` with cards for:
+  - Cache operations (`cache:clear`, `cache:warmup`)
+  - Snapshot rebuild per project
+  - Messenger queue monitoring + retry/failed job actions
+  - Doctrine migrations (check pending, run within safe mode)
+  - System health (filesystem permissions, disk usage, PHP extensions)
+- Provide REST endpoints for AJAX-triggered actions with progress feedback.
+
+## Architecture
+- Module manifest registers services, routes, navigation item (`Maintenance`, priority 50).
+- Uses Symfony Messenger for long-running tasks triggered from UI (e.g., snapshot rebuild).
+- Health checks implemented via `Symfony\Component\DependencyInjection\Compiler\ExtensionCompilerPassInterface` or dedicated services.
+
+## UI/UX
+- Cards with status badges (OK / Warning / Action required).
+- Modal confirmations for destructive actions (cache clear, migration run).
+- Activity log table showing recent maintenance actions (user, timestamp, outcome).
+
+## Integration
+- Hooks into `SnapshotManager`, `ExportManager`, `Messenger` to display status.
+- Security: restricted to users with `ROLE_SUPER_ADMIN` (or dedicated `ROLE_MAINTENANCE`).
+- Emits events (`MaintenanceActionLoggedEvent`) for audit logging.
+
+## Implementation Plan
+1. Build controller + Twig templates for dashboard layout.
+2. Wire endpoints to existing Symfony commands/services (wrap CLI operations in services).
+3. Integrate Messenger monitoring (use Doctrine transport tables).
+4. Add health check service aggregator for disk space, permissions, PHP extensions.
+
+## Considerations
+- Ensure actions run idempotently and surface errors in UI.
+- For shared hosting, avoid operations requiring shell access (no direct `exec`).
+- Provide CLI fallback commands mirroring UI actions for scripting.

--- a/docs/codex/notes/module-backup-restore.md
+++ b/docs/codex/notes/module-backup-restore.md
@@ -1,0 +1,38 @@
+# Module: Backup & Restore (P1 | Scope: L)
+
+**Status:** Draft – functionality will evolve with deployment insights.  
+**Mission:** Allow administrators to create, download, schedule, and restore backups of databases, snapshots, and uploaded assets.
+
+## Scope
+- On-demand backups triggered via `/admin/backup`.
+- Scheduled backups (daily/weekly) configurable per project or instance.
+- Backup contents: `system.brain`, `user.brain`, `data/uploads`, `data/snapshots`, optional configuration files.
+- Export format: compressed archive (`.zip` / `.tar.gz`) with manifest JSON (checksum, versions, timestamp).
+- Restore workflow with validation and optional dry-run.
+
+## Architecture
+- Module manifest registers services, routes, console commands.
+- `BackupManager` orchestrates export pipeline; streams archives to disk before download.
+- `RestoreManager` validates manifest, ensures current data is archived before overwrite, executes restore steps sequentially.
+- Utilize Symfony Messenger for long-running backup/restore jobs to keep UI responsive.
+
+## Storage & Retention
+- Local storage path `data/backups/`; allow configuring remote storage (FTP/S3) later.
+- Retention policy (keep last N backups per schedule).
+- Integrity check: SHA256 checksum stored in manifest; verify before restore.
+
+## UI/UX
+- Dashboard listing backups with date, size, status (success/failed).
+- Buttons: Download, Restore, Delete, Schedule toggle.
+- Logs displayed with steps and warnings (e.g., missing assets).
+
+## Implementation Steps
+1. Basic backup command (CLI) for manual export; integrate into module services.
+2. Admin UI & Messenger job status polling.
+3. Restore wizard (upload or select existing backup).
+4. Scheduling (Symfony scheduler/cron docs) + retention cleanup.
+
+## Open Questions
+- How do we handle backups on read-only hosting environments (ZIP streaming only)?
+- Should uploads be optional to reduce archive size (checkbox per backup)?
+- Do we need encryption for backups by default (password-protected archives)?

--- a/docs/codex/notes/module-diff-view.md
+++ b/docs/codex/notes/module-diff-view.md
@@ -1,0 +1,39 @@
+# Module: Diff View (P2 | Scope: M)
+
+**Status:** Draft – implementation window after core workflow stabilises.  
+**Goal:** Provide visual diffs between entity versions to aid review before publish.
+
+## Feature Set
+- Admin route `/admin/diff/<entity>/<version>` accessible from history view and commit modal.
+- Supports JSON diff (structured) and rendered Markdown diff.
+- Highlights resolver output changes vs raw content to clarify publish impact.
+- Optional side-by-side and inline diff modes.
+
+## Architecture
+- Module manifest registers:
+  - Services for diff calculation (`DiffEngine`, `JsonDiffFormatter`, `MarkdownDiffFormatter`).
+  - Routes under `modules/diff-view/config/routes.yaml`.
+  - Admin navigation integration (submenu item `Diff Viewer`, priority 400).
+- Uses `sebastian/diff` or custom diff engine for textual comparisons.
+- Stimulus controller for toggling diff modes and filters.
+
+## Data Flow
+1. User selects two versions (e.g., current draft vs latest active).
+2. Controller fetches payloads via `EntityVersionRepository`.
+3. Diff engine produces structured output (added, removed, changed nodes).
+4. Twig template renders diff with collapsible sections and metadata.
+
+## Dependencies
+- Relies on Draft & Version history feature for content snapshots.
+- Optional integration with Resolver pipeline to preview resolved outputs.
+- Security: restricted to admins with version-management permissions.
+
+## Implementation Notes
+- Provide API endpoint for diff JSON (to reuse in commit modal).
+- Cache recently computed diffs in `cache.app` to avoid recalculation.
+- Ensure large payloads are truncated or chunked for performance.
+
+## Future Enhancements
+- Inline comments/annotations.
+- Export diff report (PDF/HTML) for audit.
+- Integration with notifications (email summarising changes before publish).

--- a/docs/codex/notes/module-exporter.md
+++ b/docs/codex/notes/module-exporter.md
@@ -1,0 +1,46 @@
+# Module: Exporter (P1 | Scope: M)
+
+**Status:** Draft proposal – to be refined once core snapshot delivery is stable.  
+**Purpose:** Provide configurable exports (JSON, JSONL, optional TOON) derived from published snapshots, with presets and delivery endpoints.
+
+## Capabilities
+- Register admin UI under `/admin/exporter` to manage presets and trigger exports.
+- Support sync download and async background generation via Messenger.
+- Allow export profiles to select entity sets, fields, metadata, and apply content filters.
+- Deliver artifacts as downloadable files (ZIP, JSON, JSONL) with retention policy.
+
+## Architecture
+- Module manifest registers:
+  - Services (`modules/exporter/config/services.php`)
+  - Routes (`modules/exporter/config/routes.yaml`)
+  - Admin navigation (`Exporter` link, priority 200)
+  - Console command `app:exporter:run`
+- `ExportPreset` entity stored in `system.brain` (fields: slug, name, format, filters, options, last_run_at).
+- `ExportManager` orchestrates generation; uses `SnapshotReader` to fetch data.
+
+## Formats
+- **JSON:** Full dataset per preset; optional pretty-print for manual review.
+- **JSONL:** Line-delimited records; streaming writer to minimise memory.
+- **TOON (optional):** Convert JSON snapshot to TOON format; behind feature flag.
+
+## UI Flow
+1. Preset list with status (last run, last outcome).
+2. Preset editor (fields selection, filters, metadata such as usage hints).
+3. Export run: choose immediate download or queue for background processing.
+4. History tab showing completed exports (filename, size, checksum, retention expiry).
+
+## Integration
+- Depends on Snapshot feature; optional Messenger for asynchronous runs.
+- Exposes webhook/event `ExportCompletedEvent` for future automation.
+- Hooks into security to restrict usage to admins with `ROLE_EXPORTER`.
+
+## Implementation Steps
+1. Data model + services for presets and export jobs.
+2. Admin UI (Stimulus controller + Twig templates) for managing presets.
+3. Export execution engine with streaming writers.
+4. Optional queue integration and retention cleanup command.
+
+## Risks & Notes
+- Large exports: stream to disk, avoid loading entire snapshot.
+- Security: ensure exports respect project visibility + user permissions.
+- Future: integrate scheduling (cron/queue) and push-to-cloud storage adapters.

--- a/docs/codex/notes/module-frontend-theming.md
+++ b/docs/codex/notes/module-frontend-theming.md
@@ -1,0 +1,37 @@
+# Module: Frontend Theming & Site Delivery (P1 | Scope: L)
+
+**Status:** Draft – will iterate with design requirements.  
+**Objective:** Enable modular theming for public-facing sites, including theme packs, template overrides, and project-specific styling.
+
+## Capabilities
+- Theme manager UI `/admin/themes` to install, activate, and configure theme packs.
+- Theme packs include Tailwind config overrides, Twig layouts, components, and asset bundles.
+- Support per-project theme assignment with fallback to global default.
+- Allow theme-specific settings (colours, typography, layout toggles) stored as JSON and injected into Twig globals.
+- Provide preview mode: render project with alternate theme without publishing.
+
+## Architecture
+- Theme packs distributed as ZIP or Composer package containing:
+  - `theme.yaml` manifest (name, version, author, supported modules)
+  - `templates/` overrides
+  - `assets/styles/` partials
+  - `config/tailwind.extend.js` (compiled to CSS via Tailwind build)
+- Theme loader registers Twig namespace and AssetMapper paths at runtime.
+- Modules can expose theme slots (e.g., Exporter status widget) by referencing named Twig blocks.
+
+## Frontend Delivery
+- Dynamic menus & navigation integrate via Navigation Builder module.
+- Snapshot data rendered through schema-based Twig helpers.
+- Cache busting via AssetMapper hashed filenames.
+- CLI command `app:theme:build` to compile theme assets (batch builds for multiple themes).
+
+## Implementation Steps
+1. Theme manifest schema + loader service (activate/deactivate).
+2. Admin UI for theme management + configuration forms.
+3. Tailwind build pipeline per theme (build once per release).
+4. Preview controller leveraging query param (`?theme=slug`) for admin testing.
+
+## Open Questions
+- How do we isolate Tailwind builds per theme without exploding build times?
+- Should we allow runtime CSS variables injection for quick tweaks without rebuild?
+- Do we require theme dependency version checks (modules requiring certain theme capabilities)?

--- a/docs/codex/notes/module-navigation.md
+++ b/docs/codex/notes/module-navigation.md
@@ -1,0 +1,32 @@
+# Module: Navigation Builder (P1 | Scope: M)
+
+**Status:** Draft – specifics may change with UI prototyping.  
+**Purpose:** Provide dynamic site navigation management, including menus, sitemaps, and front-end integration hooks.
+
+## Features
+- Admin UI `/admin/navigation` to create/manage menus (primary, footer, contextual).
+- Menu items can reference entities, external URLs, or resolver queries.
+- Drag-and-drop ordering with depth constraints and visibility rules (per role, per locale).
+- Auto-generate sitemaps (XML/JSON) from menu definitions + entity visibility flags.
+- Frontend helper Twig functions (`navigation_render('primary')`) returning structured arrays for theme integration.
+
+## Data Model
+- `app_navigation_menu` (id, key, title, description, project_id, locale, settings JSON).
+- `app_navigation_item` (menu_id, parent_id, label, url, entity_ref, visibility rules, order, icon).
+- Versioning similar to content: drafts for menu changes with publish workflow (reuse draft/commit pipeline if feasible).
+
+## Integration
+- Modules can register default menus or add items (e.g., Exporter adds link in admin navigation).
+- Support multi-language menus via per-locale instances or translation blocks.
+- Provide API endpoint `/api/v1/navigation/{menu}` delivering JSON for SPA usage.
+
+## Implementation Plan
+1. Persistence layer + Doctrine mappings for menus/items.
+2. Admin UI with tree component (Stimulus) for editing structure.
+3. Renderer service for frontend (resolve entity slugs -> URLs).
+4. Sitemap generator + cron/command integration.
+
+## Open Questions
+- Should menu drafts reuse the main Draft/Commit infrastructure or keep a simplified workflow?
+- How do modules safely extend core menus without causing merge conflicts?
+- Do we need per-user personalised menus (feature flag for future)?

--- a/docs/codex/notes/module-relation-manager.md
+++ b/docs/codex/notes/module-relation-manager.md
@@ -1,0 +1,42 @@
+# Module: Relation Manager (P1 | Scope: M)
+
+**Status:** Draft – pending refinement alongside hierarchy implementation.  
+**Intent:** Provide tooling to manage entity hierarchy (materialized paths), reorder siblings, and manage relation-type entities.
+
+## Feature Highlights
+- Admin interface `/admin/relations` with tree view of project hierarchy.
+- Drag-and-drop ordering; batch move operations with validation (prevent moving parent into child).
+- Relation editor for creating typed links (e.g., cross-project references, navigation).
+- Bulk actions: lock/unlock, visibility toggles, menu flags.
+
+## Architecture
+- Module manifest registers tree services, routes, Stimulus controller for drag-and-drop.
+- `HierarchyService` encapsulates materialized path operations (reindex, move subtree).
+- `RelationService` manages entities of type `relation` (source, target, relation_type).
+- Use Symfony form components for relation editing with auto-complete (AJAX search).
+
+## Data & Validation
+- Materialized path column `path` + `depth` maintained via triggers or service logic.
+- Moves executed in transaction with `path` recalculation and version updates.
+- Validation ensures constraints: no deletion of parent with active children, no cycles.
+
+## UI/UX
+- Left panel tree for selection; right panel details/edit form.
+- Inline indicators (draft pending, locked, exportable).
+- Context menu for quick actions (create child, clone, move to project).
+
+## Integration
+- Works closely with Draft & Commit workflow (changes create drafts automatically when needed).
+- Exposes events `HierarchyChangedEvent`, `RelationCreatedEvent`.
+- Security: require `ROLE_CONTENT_ARCHITECT` or similar elevated role.
+
+## Implementation Roadmap
+1. Build hierarchy service + repository methods for path updates.
+2. Create API endpoints for tree fetch and reorder operations (JSON).
+3. Develop Stimulus controller for drag/drop and context actions.
+4. Integrate with commit workflow to ensure version history reflects changes.
+
+## Considerations
+- Performance: limit tree depth fetch; cache common paths.
+- Concurrency: use optimistic locking or DB constraints to avoid conflicting moves.
+- Future: allow scheduled moves or multi-project linking with approvals.

--- a/docs/dev/MANUAL.md
+++ b/docs/dev/MANUAL.md
@@ -1,21 +1,86 @@
 # Developer Manual
 
-This manual is the entry point for development workflows. Additional deep dives live under `docs/dev/sections/`.
+Status: Draft  
+Updated: 2025-10-29
 
-## Environment Bootstrap
+Welcome to the technical companion for aavion Studio. This manual outlines the development workflow, architecture conventions, and references to subsystem guides under `docs/dev/sections/`.
 
-- Run `bin/init_repository` after cloning. It installs Composer dependencies, refreshes importmap/Tailwind assets, prepares SQLite databases, ensures Messenger transports, and rebuilds caches.
-- Environment variables: `APP_ENV=dev`, `APP_DEBUG=1`, `DATABASE_URL=sqlite:///%kernel.project_dir%/var/system.brain`. Place project-specific overrides in `.env.local`.
+---
 
-## Project References
+## 1. Onboarding & environment setup
 
-- Contributor guidelines: `AGENTS.md`
-- Worklog & session notes: `docs/codex/WORKLOG.md`
-- Environment recap: `docs/codex/ENVIRONMENT.md`
-- Concept outline: `docs/codex/notes/OUTLINE.md`
-- Class map: `docs/dev/classmap.md` (must list all callable entry points; keep in sync with code)
+1. **Clone & Bootstrap**
+   ```bash
+   git clone https://github.com/dominikletica/aavionstudio.git
+   cd aavionstudio
+   bin/init_repository
+   ```
+   The script installs Composer dependencies, refreshes importmap assets, compiles Tailwind CSS, prepares SQLite databases, ensures Messenger transports, and warms caches.
 
-## Next Steps
+2. **Environment Variables**
+   - Default dev config via `.env` / `.env.dev` (`APP_ENV=dev`, `APP_DEBUG=1`, `DATABASE_URL=sqlite:///%kernel.project_dir%/var/system.brain`).
+   - Local overrides belong in `.env.local`.
 
-- Add subsystem-specific guides under `docs/dev/sections/`.
-- Keep this index updated as new tooling or processes are introduced.
+3. **Local Web Server**
+   - `symfony serve` or `php -S localhost:8000 -t public`
+   - For root fallback testing, set `APP_FORCE_ROOT_ENTRY=1` and hit `index.php`.
+
+---
+
+## 2. Project directory map
+
+| Path | Purpose |
+|------|---------|
+| `src/` | Symfony application code (controllers, services, modules) |
+| `modules/` | Optional feature modules (service manifests, assets, templates) |
+| `assets/` | Tailwind styles, Stimulus controllers, JS modules |
+| `public/` | Webroot (front controller, built assets) |
+| `data/` | Snapshots, uploads, backups |
+| `var/` | Cache, logs, SQLite databases (`system.brain`, `user.brain`) |
+| `docs/` | Documentation (developer, user, codex notes) |
+
+---
+
+## 3. Core workflows
+
+- **Coding Standards**
+  - PHP: PSR-12, strict types when applicable, service autowiring/autoconfigure.
+  - Frontend: Tailwind utility classes, Stimulus controllers (`snake_controller.js`), AssetMapper imports.
+  - Translations: English only (`admin`, `validators`, etc.).
+
+- **Testing**
+  - PHPUnit for unit/integration; plan to add Panther/Cypress for UI flows.
+  - Use SQLite in-memory for unit tests; attach `user.brain` if needed.
+  - Run `php bin/phpunit --coverage-text` before PRs.
+
+- **Documentation Discipline**
+  - Update module/feature drafts in `docs/codex/notes/` as behaviour changes.
+  - Keep class map (`docs/dev/classmap.md`) in sync with new services/commands/components.
+  - Log session progress in `docs/codex/WORKLOG.md`.
+
+---
+
+## 4. Reference index
+
+- **Contributor Guidelines:** [`AGENTS.md`](../../AGENTS.md)
+- **Worklog & Session Notes:** [`docs/codex/WORKLOG.md`](../codex/WORKLOG.md)
+- **Environment Recap:** [`docs/codex/ENVIRONMENT.md`](../codex/ENVIRONMENT.md)
+- **Concept Outline & Feature Drafts:** [`docs/codex/notes/`](../codex/notes/)
+- **Developer Sections:** `docs/dev/sections/` (add guides per subsystem)
+- **Class Map:** [`docs/dev/classmap.md`](classmap.md)
+
+---
+
+## 5. Open tasks & roadmap
+
+Consult the live TODOs and roadmap in `docs/codex/WORKLOG.md`. Each feature has a dedicated draft outlining architecture, dependencies, and testing strategy.
+
+---
+
+## 6. Contributing guides (to be expanded)
+
+- **Subsystem Guides:** Document specifics under `docs/dev/sections/` (e.g., resolver, snapshot manager, module system).
+- **API Reference:** Maintain OpenAPI specs and usage notes once the read/write APIs stabilise.
+- **Deployment Recipes:** Capture shared-hosting vs container deployment steps.
+
+Keep this manual updated as new tooling, scripts, or architectural decisions emerge.

--- a/docs/dev/classmap.md
+++ b/docs/dev/classmap.md
@@ -1,0 +1,87 @@
+# Developer Class Map (Draft)
+
+> **Status:** This document tracks callable entry points (services, commands, controllers, Twig components, Stimulus controllers). Keep it up to date as new classes are added or interfaces change.
+
+---
+
+## 1. Symfony Services
+
+| Service ID | Class | Responsibility | Notes |
+|------------|-------|----------------|-------|
+| `App\Kernel` | `src/Kernel.php` | Application kernel | Uses MicroKernelTrait |
+| _TBD_ |  |  | Populate as services are introduced |
+
+### Suggested Structure
+- **Core Services:** Module loader, schema registry, draft manager, snapshot manager, resolver engine, media storage.
+- **Infrastructure Services:** Cache, lock, messenger transports.
+- **Integrations:** Exporter manager, webhook dispatcher, backup manager.
+
+For each service added to `config/services.yaml` or module manifests, document:
+- Constructor signature (important dependencies).
+- Key methods and event hooks.
+- Related tests (link to PHPUnit class).
+
+---
+
+## 2. Controllers
+
+| Route Name | Class | Description | Module |
+|------------|-------|-------------|--------|
+| `app_frontend` | _TBD_ | Catch-all frontend controller | Core |
+| `app_admin_dashboard` | _TBD_ | Admin landing page | Core |
+| ... |  |  |  |
+
+---
+
+## 3. Console Commands
+
+| Command | Class | Description | Dependencies |
+|---------|-------|-------------|--------------|
+| `app:snapshot:rebuild` | _TBD_ | Rebuild published snapshots | SnapshotManager |
+| `app:backup:run` | _TBD_ | Create backup archive | BackupManager |
+| ... |  |  |  |
+
+---
+
+## 4. Twig Components & Extensions
+
+| Identifier | Class/Template | Purpose |
+|------------|----------------|---------|
+| `App\Twig\Components\NavSidebar` | _TBD_ | Render admin navigation |
+| Twig Extension | _TBD_ | Custom filters/functions for schema rendering |
+
+Document:
+- Component props/context.
+- Slots or blocks used.
+- Template paths (`templates/components/...`).
+
+---
+
+## 5. Stimulus Controllers
+
+| Controller Name | File | Description |
+|-----------------|------|-------------|
+| `codemirror` | `assets/controllers/codemirror_controller.js` | Enhances textareas with CodeMirror editor |
+| `hello` | `assets/controllers/hello_controller.js` | Example scaffold (remove/replace) |
+| ... |  |  |
+
+---
+
+## 6. Modules Registry (Future Entries)
+
+Record module manifest classes/files and their contributions:
+
+| Module | Manifest Path | Services | Routes | Assets |
+|--------|---------------|----------|--------|--------|
+| Exporter | `modules/exporter/module.php` | `modules/exporter/config/services.php` | `modules/exporter/config/routes.yaml` | `modules/exporter/assets/...` |
+| Maintenance | ... | ... | ... | ... |
+
+---
+
+## Maintenance Tips
+- Whenever adding a new service/controller/command, update this map.
+- Cross-link to relevant drafts in `docs/codex/notes/`.
+- Include test class references to ease traceability (`tests/...`).
+- Mark deprecated entries clearly when refactoring.
+
+This document is meant to evolve alongside the codebase—treat it as a living index for developers to quickly discover callables without grepping through the project.

--- a/docs/dev/sections/architecture/README.md
+++ b/docs/dev/sections/architecture/README.md
@@ -1,0 +1,15 @@
+# Architecture guides
+
+Status: Draft  
+Updated: 2025-10-29
+
+Use this section to document high-level architecture concerns.
+
+Suggested topics:
+- Module system & manifest loader
+- Persistence layer (Doctrine, SQLite dual DB setup)
+- Snapshot pipeline architecture
+- Resolver pipeline internals
+- Media storage & delivery
+
+Sub-guides should live in separate Markdown files within this directory.

--- a/docs/dev/sections/modules/README.md
+++ b/docs/dev/sections/modules/README.md
@@ -1,0 +1,13 @@
+# Modules & extensions
+
+Status: Draft  
+Updated: 2025-10-29
+
+Use this directory to document module-specific behaviour and extension points.
+Potential sub-guides:
+- Exporter module architecture & APIs
+- Maintenance console actions & permissions
+- Navigation builder data model
+- Theming system (manifest schema, overrides)
+- Backup & restore workflow
+- Optional integrations (Diff view, write API hooks)

--- a/docs/dev/sections/testing/README.md
+++ b/docs/dev/sections/testing/README.md
@@ -1,0 +1,12 @@
+# Testing & quality
+
+Status: Draft  
+Updated: 2025-10-29
+
+Document testing strategy and tooling here, such as:
+- PHPUnit conventions (unit/integration naming, fixtures)
+- Frontend/UI testing (Panther, Cypress, Stimulus harnesses)
+- Code coverage expectations and thresholds
+- Continuous integration scripts / GitHub Actions
+- Debugging tips for failing tests
+- Performance profiling guidance

--- a/docs/dev/sections/workflows/README.md
+++ b/docs/dev/sections/workflows/README.md
@@ -1,0 +1,11 @@
+# Development workflows
+
+Status: Draft  
+Updated: 2025-10-29
+
+Use this folder to capture repeatable workflows and SOPs, e.g.:
+- Running init scripts and local servers
+- Performing database migrations
+- Publishing snapshots and exports
+- Handling feature flags / environment toggles
+- Release packaging (shared hosting ZIP, composer installs)

--- a/docs/templates/dev-guide-template.md
+++ b/docs/templates/dev-guide-template.md
@@ -1,0 +1,28 @@
+# {{ Title }} (Developer Guide)
+
+Status: Draft  
+Updated: {{ YYYY-MM-DD }}
+
+## Overview
+- Purpose and scope of this guide.
+- Modules or systems it touches.
+- Dependencies (services, configs, feature flags).
+
+## Architecture Notes
+- High-level flow or diagrams (if applicable).
+- Key classes, interfaces, and events involved.
+- Configuration files or environment variables.
+
+## Implementation Steps
+1. Outline steps or phases to implement/extend the feature.
+2. Reference relevant services or draft documents.
+3. Highlight testing considerations.
+
+## Testing & Validation
+- Unit/integration test expectations.
+- Manual verification steps, if any.
+- Metrics or logs to monitor.
+
+## References
+- Links to code, schemas, feature drafts, or external docs.
+- Related module documentation.

--- a/docs/templates/user-guide-template.md
+++ b/docs/templates/user-guide-template.md
@@ -1,0 +1,28 @@
+# {{ Title }} (User Guide)
+
+Status: Draft  
+Updated: {{ YYYY-MM-DD }}
+
+## Summary
+- What is this feature/section about?
+- Who is the intended audience?
+- Key prerequisites or permissions.
+
+## Prerequisites
+- Environment or configuration requirements.
+- Roles needed to access menus/features.
+- Links to related guides.
+
+## Steps
+1. Step-by-step instructions with screenshots or callouts.
+2. Use numbered lists for ordered workflows.
+3. Embed code blocks for CLI commands if necessary.
+
+## Tips & Troubleshooting
+- Common issues and resolutions.
+- Notes about limitations or feature flags.
+- Links to support resources.
+
+## Related Guides
+- [Link to another user section](../sections/.../README.md)
+- [Developer reference if relevant](../../dev/sections/.../README.md)

--- a/docs/user/MANUAL.md
+++ b/docs/user/MANUAL.md
@@ -1,1 +1,72 @@
-Placeholder: entry-point and index for user manuals. Childs go to `docs/user/sections/`.
+# aavion Studio – User Manual
+
+Status: Draft  
+Updated: 2025-10-29
+
+Welcome! This manual will guide administrators, editors, and integrators through installing, configuring, and using aavion Studio. The content below provides an overview of the documentation structure; detailed guides live under `docs/user/sections/`.
+
+---
+
+## 1. Getting started
+
+- **Introduction & Concepts** – What makes aavion Studio different (schema-driven content, draft → commit, snapshots).
+- **System Requirements** – PHP 8.2+, SQLite support, web server configuration (Apache/nginx/IIS) with rewrite or root loader fallback.
+- **Quick Installation** – Using the browser installer vs. manual configuration.
+- **Post-Install Checklist** – Create first admin, configure email, set up backups, enable modules.
+
+---
+
+## 2. Administration guide
+
+- **Dashboard Overview** – Navigating the Admin Studio UI, notifications, search palette.
+- **Projects & Settings** – Managing projects, locales, error-page entities (default project provides fallback Twig templates).
+- **User & Access Management** – Creating users, assigning roles/permissions, managing API keys.
+- **Maintenance Tools** – Cache, snapshot rebuild, queue monitoring, health checks.
+
+---
+
+## 3. Content authoring
+
+- **Schema & Templates** – Selecting content models, understanding fields, previewing templates.
+- **Draft Workflow** – Creating drafts, autosave, collaboration tips.
+- **Commit & Publish** – Reviewing diffs, resolving validation errors, publishing snapshots.
+- **Shortcodes & Resolver** – Using `[ref]` and `[query]`, handling errors, best practices.
+- **Media Library** – Uploading files, managing metadata, embedding media.
+- **Navigation & Menus** – Building site menus, visibility rules, sitemaps.
+
+---
+
+## 4. Site delivery & theming
+
+- **Front-End Themes** – Activating theme packs, adjusting settings, preview mode.
+- **Error Pages** – Assigning project-specific entities as error views with fallback Twig templates.
+- **Custom Pages & Components** – Extending Twig templates, injecting modules.
+- **Caching & Performance** – Understanding snapshot delivery, cache invalidation triggers.
+
+---
+
+## 5. Integrations & exports
+
+- **Read API** – Consuming published snapshots via REST.
+- **Write API (optional)** – Automating content creation with API keys & scopes.
+- **Exporter Module** – Configuring presets, running JSON/JSONL/TOON exports.
+- **Backup & Restore** – Scheduling backups, storing archives, restoring safely.
+
+---
+
+## 6. Troubleshooting & FAQ
+
+- **Installer Issues** – Common errors in shared hosting environments.
+- **Resolver Errors** – Interpreting error codes and fixing content.
+- **Snapshot Problems** – Debugging missing data or outdated views.
+- **Support Channels** – Where to file issues and contact the maintainer.
+
+---
+
+## 7. Documentation structure
+
+- Detailed guides are stored in `docs/user/sections/` for each topic above.
+- Keep this index updated as new features become available.
+- Contributors should ensure screenshots, walkthroughs, and FAQs stay in sync with the UI.
+
+Happy publishing!

--- a/docs/user/sections/administration/README.md
+++ b/docs/user/sections/administration/README.md
@@ -1,0 +1,11 @@
+# Administration
+
+Status: Draft  
+Updated: 2025-10-29
+
+Topics to cover:
+- Projects & settings management
+- User roles, permissions, API keys
+- Module management & feature toggles
+- Maintenance console usage (cache, snapshots, queues, health checks)
+- Backup & restore operations

--- a/docs/user/sections/content/README.md
+++ b/docs/user/sections/content/README.md
@@ -1,0 +1,11 @@
+# Content authoring
+
+Status: Draft  
+Updated: 2025-10-29
+
+Suggested structure:
+- Working with schemas & templates
+- Draft creation, autosave, collaboration hints
+- Commit process & diff review
+- Shortcodes (`[ref]`, `[query]`) and resolver feedback
+- Media library usage within content

--- a/docs/user/sections/getting-started/README.md
+++ b/docs/user/sections/getting-started/README.md
@@ -1,0 +1,11 @@
+# Getting started
+
+Status: Draft  
+Updated: 2025-10-29
+
+Outline for onboarding content:
+- Introduction to key concepts (projects, schemas, drafts, snapshots)
+- System requirements & hosting options
+- Installation walkthrough (browser installer vs manual)
+- Initial configuration (admin user, locales, error pages)
+- Quick tour of Admin Studio UI

--- a/docs/user/sections/integrations/README.md
+++ b/docs/user/sections/integrations/README.md
@@ -1,0 +1,11 @@
+# Integrations & exports
+
+Status: Draft  
+Updated: 2025-10-29
+
+Areas to document:
+- Read API consumption
+- Write API usage (if enabled) and scopes
+- Exporter module (JSON/JSONL/TOON) workflows
+- Webhooks & automation patterns
+- Third-party tool integrations (LLM pipelines, data pipelines)

--- a/docs/user/sections/site-delivery/README.md
+++ b/docs/user/sections/site-delivery/README.md
@@ -1,0 +1,11 @@
+# Site delivery & theming
+
+Status: Draft  
+Updated: 2025-10-29
+
+Key topics:
+- Activating and configuring themes
+- Previewing theme changes safely
+- Error page management (project entities vs Twig fallback templates)
+- Navigation builder integration with themes
+- Caching & performance considerations for published sites

--- a/docs/user/sections/troubleshooting/README.md
+++ b/docs/user/sections/troubleshooting/README.md
@@ -1,0 +1,12 @@
+# Troubleshooting & FAQ
+
+Status: Draft  
+Updated: 2025-10-29
+
+Consider documenting:
+- Installer issues (permissions, PHP extensions)
+- Resolver error codes and fixes
+- Snapshot / cache inconsistencies
+- Media upload failures
+- Backup/restore pitfalls
+- Support channels & diagnostic steps


### PR DESCRIPTION
### 2025-10-29 (Session 2)
- Kicked off feature-outline drafting for modular architecture and implementation planning
- Added detailed drafts for core platform, workflow, resolver, snapshot/API, and initial modules
- Established documentation style guide, templates, manuals, and tooling for parallel doc updates
- Expanded draft library covering user management, admin studio, schema/templates, write API, caching, theming, navigation, backup, and diff tooling
- Reorganised TODOs by feature/module with granular tasks for implementation planning
---
@codex review
closes #3 