### PR TITLE
Fix: Update release.json atomic during release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -25,14 +25,16 @@ BUILD_DIR="$ROOT_DIR/build"
 STAGE_DIR="$BUILD_DIR/${APP_ENV}-${VERSION}-${CHANNEL}"
 ZIP_NAME="aavionstudio-${VERSION}-${CHANNEL}.zip"
 ZIP_PATH="$BUILD_DIR/$ZIP_NAME"
+RELEASE_METADATA_PATH="$BUILD_DIR/release.json"
+RELEASE_METADATA_TMP="$ROOT_DIR/release.json.tmp"
 COMMIT_SHA="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
 GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 echo ">>> Preparing release $VERSION ($CHANNEL) for environment '$APP_ENV'"
 
-rm -f "$ROOT_DIR/release.json"
+mkdir -p "$BUILD_DIR"
 
-cat > "$ROOT_DIR/release.json" <<JSON
+cat > "$RELEASE_METADATA_PATH" <<JSON
 {
   "version": "$VERSION",
   "channel": "$CHANNEL",
@@ -42,7 +44,10 @@ cat > "$ROOT_DIR/release.json" <<JSON
 }
 JSON
 
-mkdir -p "$BUILD_DIR"
+rm -f "$RELEASE_METADATA_TMP"
+cp "$RELEASE_METADATA_PATH" "$RELEASE_METADATA_TMP"
+mv "$RELEASE_METADATA_TMP" "$ROOT_DIR/release.json"
+
 rm -rf "$STAGE_DIR"
 
 EXCLUDES=(

--- a/docs/codex/WORKLOG.md
+++ b/docs/codex/WORKLOG.md
@@ -170,3 +170,6 @@
 - Added release automation (`bin/release`) creating environment/version/channel-specific packages with metadata
 - Clarified documentation portals, manuals, and release workflow references; added user/dev section skeletons and class map
 - Generated dummy `release.json` for tooling; release script now cleans Tailwind binaries and rewrites metadata ahead of staging
+
+### 2025-10-30 (Session 2)
+- Adjusted release script to generate metadata inside the build directory and atomically refresh the tracked `release.json`, plus aligned the release workflow guide

--- a/docs/dev/sections/workflows/release.md
+++ b/docs/dev/sections/workflows/release.md
@@ -31,7 +31,7 @@ Note: The repository may ship with a placeholder `release.json` for tooling/test
    - Refresh importmap assets, build Tailwind CSS, and remove downloaded Tailwind binaries
    - Warm the Symfony cache for the chosen environment
    - Stage a clean copy in `build/<env>-<version>-<channel>/`
-   - Write `RELEASE.json` containing version metadata (commit, timestamp, channel)
+   - Generate release metadata in `build/release.json` and atomically update the repository `release.json`
    - Package the archive at `build/aavionstudio-<version>-<channel>.zip`
 5. Distribute the generated ZIP. The installer will generate real secrets (`APP_SECRET`, etc.) on first run.
 


### PR DESCRIPTION
## Summary
- generate release metadata inside the build directory and atomically refresh the tracked release.json
- document the new release.json handling in the release workflow guide
- record the adjustments in the worklog under the current session

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69030dcd26188331bc09b684b13ecb63